### PR TITLE
Build static binary using alpine and docker (does not work)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:edge
+
+RUN apk update && apk add crystal shards gcc g++ cmake make
+
+RUN apk add \
+    vips-dev \
+    libressl-dev \
+    zlib-dev \
+    lexbor-dev \
+    yaml-dev \
+    discount-dev \
+    libxml2-dev

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,10 @@ mt-release:
 	cat .rucksack >> bin/nicolino
 lint:
 	bin/ameba --all --fix
+static:
+	# Sadly doesn't work because there is no static libdiscount in alpine
+	docker build . -t nicolino-builder
+	docker run -ti -v .:/src -w /src crystal shards build --static
+
 
 .PHONY: clean all test bin lint


### PR DESCRIPTION
The idea is good, but alpine has no static libdiscount nor libvips, so no static binaries yet